### PR TITLE
Fix DataBinding leak on fragments.

### DIFF
--- a/mvvm/src/androidMain/kotlin/dev/icerock/moko/mvvm/MvvmFragment.kt
+++ b/mvvm/src/androidMain/kotlin/dev/icerock/moko/mvvm/MvvmFragment.kt
@@ -16,7 +16,10 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 
 abstract class MvvmFragment<DB : ViewDataBinding, VM : ViewModel> : Fragment() {
-    protected lateinit var binding: DB
+    private var _binding: DB? = null
+    protected val binding: DB
+        get() = _binding!!
+
     protected lateinit var viewModel: VM
 
     protected abstract val layoutId: Int
@@ -39,7 +42,7 @@ abstract class MvvmFragment<DB : ViewDataBinding, VM : ViewModel> : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = DataBindingUtil.inflate(inflater, layoutId, container, false)
+        _binding = DataBindingUtil.inflate(inflater, layoutId, container, false)
         binding.lifecycleOwner = this
         return binding.root
     }
@@ -48,5 +51,10 @@ abstract class MvvmFragment<DB : ViewDataBinding, VM : ViewModel> : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         binding.setVariable(viewModelVariableId, viewModel)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/sample/android-app/src/main/AndroidManifest.xml
+++ b/sample/android-app/src/main/AndroidManifest.xml
@@ -23,5 +23,6 @@
         <activity android:name=".sample4.ValidationMergeActivity" />
         <activity android:name=".sample5.ValidationAllActivity" />
         <activity android:name=".sample6.LoginActivity" />
+        <activity android:name=".sample7.ContainerActivity" />
     </application>
 </manifest>

--- a/sample/android-app/src/main/java/com/icerockdev/app/MainActivity.kt
+++ b/sample/android-app/src/main/java/com/icerockdev/app/MainActivity.kt
@@ -15,6 +15,7 @@ import com.icerockdev.app.sample3.EventsOwnerActivity
 import com.icerockdev.app.sample4.ValidationMergeActivity
 import com.icerockdev.app.sample5.ValidationAllActivity
 import com.icerockdev.app.sample6.LoginActivity
+import com.icerockdev.app.sample7.ContainerActivity
 import kotlin.reflect.KClass
 
 class MainActivity : AppCompatActivity() {
@@ -46,6 +47,10 @@ class MainActivity : AppCompatActivity() {
 
     fun onSample6ButtonPressed(view: View) {
         openScreen(LoginActivity::class)
+    }
+
+    fun onSample7ButtonPressed(view: View) {
+        openScreen(ContainerActivity::class)
     }
 
     private fun openScreen(clazz: KClass<out Activity>) {

--- a/sample/android-app/src/main/java/com/icerockdev/app/sample7/ContainerActivity.kt
+++ b/sample/android-app/src/main/java/com/icerockdev/app/sample7/ContainerActivity.kt
@@ -1,0 +1,14 @@
+package com.icerockdev.app.sample7
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.icerockdev.app.R
+
+class ContainerActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_container)
+    }
+
+}

--- a/sample/android-app/src/main/java/com/icerockdev/app/sample7/SimpleFragment.kt
+++ b/sample/android-app/src/main/java/com/icerockdev/app/sample7/SimpleFragment.kt
@@ -1,0 +1,21 @@
+package com.icerockdev.app.sample7
+
+import androidx.lifecycle.ViewModelProvider
+import com.icerockdev.app.BR
+import com.icerockdev.app.R
+import com.icerockdev.app.databinding.FragmentSimpleBinding
+import com.icerockdev.library.sample1.SimpleViewModel
+import dev.icerock.moko.mvvm.MvvmFragment
+import dev.icerock.moko.mvvm.createViewModelFactory
+
+class SimpleFragment : MvvmFragment<FragmentSimpleBinding, SimpleViewModel>() {
+
+    override val layoutId: Int = R.layout.fragment_simple
+    override val viewModelVariableId: Int = BR.viewModel
+    override val viewModelClass: Class<SimpleViewModel> = SimpleViewModel::class.java
+
+    override fun viewModelFactory(): ViewModelProvider.Factory {
+        return createViewModelFactory { SimpleViewModel() }
+    }
+
+}

--- a/sample/android-app/src/main/res/layout/activity_container.xml
+++ b/sample/android-app/src/main/res/layout/activity_container.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <fragment
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:name="com.icerockdev.app.sample7.SimpleFragment"
+        android:tag="SimpleFragment"/>
+
+</LinearLayout>

--- a/sample/android-app/src/main/res/layout/activity_main.xml
+++ b/sample/android-app/src/main/res/layout/activity_main.xml
@@ -47,4 +47,11 @@
         android:layout_marginTop="8dp"
         android:onClick="onSample6ButtonPressed"
         android:text="Sample 6" />
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:onClick="onSample7ButtonPressed"
+        android:text="Sample 7" />
 </LinearLayout>

--- a/sample/android-app/src/main/res/layout/fragment_simple.xml
+++ b/sample/android-app/src/main/res/layout/fragment_simple.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="com.icerockdev.library.sample1.SimpleViewModel" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@{viewModel.counter.ld}" />
+
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:onClick="@{() -> viewModel.onCounterButtonPressed()}"
+            android:text="Press me to count" />
+    </LinearLayout>
+</layout>


### PR DESCRIPTION
See #68 
**Fix DataBinding leak on fragments:**
``` 
private var _binding: DB? = null
protected val binding: DB
    get() = _binding!!
```

I suggest using a private var initialized null and a protected val with getter to _binding!!. There is no problem using "!!" in this case because we know we only use this after setting in onCreateView() and before onDestroyView() the same case as the lateinit var used before.

```
override fun onDestroyView() {
    super.onDestroyView()
    _binding = null
}
```
Later in onDestroyView() _binding is cleared to avoid memory leaks.

**Add SimpleFragment example:**

Add sample7->ContainerActivity->SimpleFragment -> SimpleViewModel