### PR TITLE
Clarify SwiftUI ViewModel state null semantics

### DIFF
--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelBinding.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelBinding.swift
@@ -1,5 +1,5 @@
 //
-//  CFlowExt.swift
+//  ViewModelBinding.swift
 //  mokoMvvmFlowSwiftUI (iOS)
 //
 //  Created by Aleksey Mikhailov on 29.04.2022.

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelObservable.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelObservable.swift
@@ -1,5 +1,5 @@
 //
-//  CFlowExt.swift
+//  ViewModelObservable.swift
 //  mokoMvvmFlowSwiftUI (iOS)
 //
 //  Created by Aleksey Mikhailov on 29.04.2022.

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelState.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelState.swift
@@ -1,5 +1,5 @@
 //
-//  CFlowExt.swift
+//  ViewModelState.swift
 //  mokoMvvmFlowSwiftUI (iOS)
 //
 //  Created by Aleksey Mikhailov on 29.04.2022.

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelState.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelState.swift
@@ -26,6 +26,7 @@ public extension ObservableObject where Self: ViewModel {
                 lastValue = value!
                 self?.objectWillChange.send()
                 disposable?.dispose()
+                disposable = nil
             }
         })
         

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelState.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelState.swift
@@ -93,4 +93,12 @@ public extension ObservableObject where Self: ViewModel {
             mapper: { $0 as! Array<T> }
         )
     }
+
+    func state<T: KotlinBase>(_ flowKey: KeyPath<Self, CStateFlow<T>>) -> T {
+        return state(
+            flowKey,
+            equals: { $0.isEqual($1) },
+            mapper: { $0 }
+        )
+    }
 }

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelState.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelState.swift
@@ -13,17 +13,17 @@ public extension ObservableObject where Self: ViewModel {
 
     func state<T, R>(
         _ flowKey: KeyPath<Self, CStateFlow<T>>,
-        equals: @escaping (T?, T?) -> Bool,
+        equals: @escaping (T, T) -> Bool,
         mapper: @escaping (T) -> R
     ) -> R {
         let stateFlow: CStateFlow<T> = self[keyPath: flowKey]
-        var lastValue: T? = stateFlow.value
-        
+        var lastValue: T = stateFlow.value!
+
         var disposable: DisposableHandle? = nil
         
         disposable = stateFlow.subscribe(onCollect: { [weak self] value in
-            if !equals(lastValue, value) {
-                lastValue = value
+            if !equals(lastValue, value!) {
+                lastValue = value!
                 self?.objectWillChange.send()
                 disposable?.dispose()
             }
@@ -35,7 +35,7 @@ public extension ObservableObject where Self: ViewModel {
     func state(_ flowKey: KeyPath<Self, CStateFlow<KotlinBoolean>>) -> Bool {
         return state(
             flowKey,
-            equals: { $0?.boolValue == $1?.boolValue },
+            equals: { $0.boolValue == $1.boolValue },
             mapper: { $0.boolValue }
         )
     }
@@ -43,7 +43,7 @@ public extension ObservableObject where Self: ViewModel {
     func state(_ flowKey: KeyPath<Self, CStateFlow<KotlinDouble>>) -> Double {
         return state(
             flowKey,
-            equals: { $0?.doubleValue == $1?.doubleValue },
+            equals: { $0.doubleValue == $1.doubleValue },
             mapper: { $0.doubleValue }
         )
     }
@@ -51,7 +51,7 @@ public extension ObservableObject where Self: ViewModel {
     func state(_ flowKey: KeyPath<Self, CStateFlow<KotlinFloat>>) -> Float {
         return state(
             flowKey,
-            equals: { $0?.floatValue == $1?.floatValue },
+            equals: { $0.floatValue == $1.floatValue },
             mapper: { $0.floatValue }
         )
     }
@@ -59,7 +59,7 @@ public extension ObservableObject where Self: ViewModel {
     func state(_ flowKey: KeyPath<Self, CStateFlow<KotlinInt>>) -> Int {
         return state(
             flowKey,
-            equals: { $0?.intValue == $1?.intValue },
+            equals: { $0.intValue == $1.intValue },
             mapper: { $0.intValue }
         )
     }
@@ -67,7 +67,7 @@ public extension ObservableObject where Self: ViewModel {
     func state(_ flowKey: KeyPath<Self, CStateFlow<KotlinLong>>) -> Int64 {
         return state(
             flowKey,
-            equals: { $0?.int64Value == $1?.int64Value },
+            equals: { $0.int64Value == $1.int64Value },
             mapper: { $0.int64Value }
         )
     }
@@ -84,14 +84,10 @@ public extension ObservableObject where Self: ViewModel {
         return state(
             flowKey,
             equals: { oldValue, newValue in
-                if let oldValue = oldValue {
-                    guard let newValue = newValue as? Array<T> else {
-                        return false
-                    }
-                    return oldValue.isEqual(to: newValue)
-                } else {
-                    return newValue == nil
+                guard let newValue = newValue as? Array<T> else {
+                    return false
                 }
+                return oldValue.isEqual(to: newValue)
             },
             mapper: { $0 as! Array<T> }
         )

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
@@ -1,6 +1,6 @@
 //
 //  ViewModelStateNullable.swift
-//  mokoMvvmFlow
+//  mokoMvvmFlowSwiftUI (iOS)
 //
 //  Created by mdubkov on 25.09.2022.
 //

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
@@ -79,9 +79,18 @@ extension ObservableObject where Self: ViewModel {
     }
     
     func stateNullable<T>(_ flowKey: KeyPath<Self, CStateFlow<NSArray>>) -> Array<T>? {
-        return state(
+        return stateNullable(
             flowKey,
-            equals: { $0 === $1 },
+            equals: { oldValue, newValue in
+                if let oldValue = oldValue {
+                    guard let newValue = newValue as? Array<T> else {
+                        return false
+                    }
+                    return oldValue.isEqual(to: newValue)
+                } else {
+                    return newValue == nil
+                }
+            },
             mapper: { $0 as? Array<T> }
         )
     }

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
@@ -24,6 +24,7 @@ extension ObservableObject where Self: ViewModel {
                 lastValue = value
                 self?.objectWillChange.send()
                 disposable?.dispose()
+                disposable = nil
             }
         })
         

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
@@ -103,4 +103,12 @@ extension ObservableObject where Self: ViewModel {
             mapper: { $0?.localized() }
         )
     }
+
+    func stateNullable<T: KotlinBase>(_ flowKey: KeyPath<Self, CStateFlow<T>>) -> T? {
+        return stateNullable(
+            flowKey,
+            equals: { $0?.isEqual($1) == true },
+            mapper: { $0 }
+        )
+    }
 }

--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/mokoMvvmFlowSwiftUI.h
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/mokoMvvmFlowSwiftUI.h
@@ -1,6 +1,6 @@
 //
 //  mokoMvvmFlowSwiftUI.h
-//  mokoMvvmFlowSwiftUI
+//  mokoMvvmFlowSwiftUI (iOS)
 //
 //  Created by Aleksey Mikhailov on 29.04.2022.
 //


### PR DESCRIPTION
This simplifies code and cleans up call-site use, and makes it explicit when to use each helper. When your Kotlin ViewModel `StateFlow` has non-optional values, use the `state` helper in SwiftUI. When your `StateFlow` has an optional type and might have `null` values, use `stateNullable` in SwiftUI.

Note: There isn't compiler help when deciding between `state` and `stateNullable` in SwiftUI. Choosing `state` where `stateNullable` is required will cause a runtime crash due to force unwrapping. Take care to use the correct helper.

This PR also introduces `state` and `stateNullable` helpers for `KotlinBase`. When Kotlin/Native exports to Objective-C, all custom classes share a common `KotlinBase` interface (which implements `NSObject` and has `isEqual` available).

This simplification makes the library slightly easier to use and perhaps a little more intuitive. Instead of forcing callers through `state(_:equals:mapper:)` for custom types and making them define their own `equals` and `mapper`, it's now possible to just use the simpler `state(_)` helper.