### PR TITLE
Fix compiler error in Swift UI helpers when not using moko-resources

### DIFF
--- a/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
+++ b/mvvm-flow/apple/xcode/mokoMvvmFlowSwiftUI/ViewModelStateNullable.swift
@@ -95,14 +95,6 @@ extension ObservableObject where Self: ViewModel {
             mapper: { $0 as? Array<T> }
         )
     }
-    
-    func stateNullable(_ flowKey: KeyPath<Self, CStateFlow<StringDesc>>) -> String? {
-        return stateNullable(
-            flowKey,
-            equals: { $0 === $1 },
-            mapper: { $0?.localized() }
-        )
-    }
 
     func stateNullable<T: KotlinBase>(_ flowKey: KeyPath<Self, CStateFlow<T>>) -> T? {
         return stateNullable(


### PR DESCRIPTION
The `StringDesc` protocol comes from projects that also incorporate [moko-resources](https://github.com/icerockdev/moko-resources). For projects that use only moko-mvvm, this code was generating a compiler error:

```
ViewModelStateNullable.swift:99:60: Cannot find type 'StringDesc' in scope
```

Note that this particular helper didn't have a corresponding `state` version in `ViewModelState`. After this change, both `state` and `stateNullable` are consistent in terms of the methods they offer.