### PR TITLE
Replaced a deprecated usage of the `launchWhenStarted` property

### DIFF
--- a/mvvm-flow/src/androidMain/kotlin/dev/icerock/moko/mvvm/flow/binding/BindingBase.kt
+++ b/mvvm-flow/src/androidMain/kotlin/dev/icerock/moko/mvvm/flow/binding/BindingBase.kt
@@ -4,21 +4,26 @@
 
 package dev.icerock.moko.mvvm.flow.binding
 
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.DisposableHandle
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 
 fun <T> StateFlow<T>.bind(
     lifecycleOwner: LifecycleOwner,
     observer: (T) -> Unit
 ): DisposableHandle {
     val self: StateFlow<T> = this
-    val job: Job = lifecycleOwner.lifecycleScope.launchWhenStarted {
-        self.onEach { observer(it) }.collect()
+    val job: Job = lifecycleOwner.lifecycleScope.launch {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            self.onEach { observer(it) }.collect()
+        }
     }
     return DisposableHandle { job.cancel() }
 }


### PR DESCRIPTION
@Alex009, the `launchWhenStarted` extension got deprecated, [see here][ref].

> **Warning:** Prefer collecting flows using the repeatOnLifecycle API instead of collecting inside the launchWhenX APIs. As the latter APIs suspend the coroutine instead of cancelling it when the Lifecycle is STOPPED, upstream flows are kept active in the background, potentially emitting new items and wasting resources.

[ref]: https://developer.android.com/topic/libraries/architecture/coroutines